### PR TITLE
updated for Dokuwiki librarian 2025-05-14. 

### DIFF
--- a/action.php
+++ b/action.php
@@ -5,46 +5,39 @@
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  lisps
+ * @author  einhirn
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once DOKU_PLUGIN.'action.php';
-//require_once DOKU_PLUGIN.'edittable/common.php';
+use dokuwiki\Extension\ActionPlugin;
+use dokuwiki\Extension\EventHandler;
+use dokuwiki\Extension\Event;
 
 class action_plugin_nosecedit extends DokuWiki_Action_Plugin
-	{
-	var $helper = FALSE;
-	
-	/**
-	 * set a databuffer :-)	
-	 */
-	function action_plugin_nosecedit()
-		{	
-		}
-	
+{
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller)
-    	{
+    public function register(EventHandler $controller)
+    {
         $controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, 'html_secedit_button');
-    	}
+    }
 
-    function html_secedit_button(&$event)
-    	{
-	    global $ID;
-	    
-	    //Section event?
-        if ($event->data['target'] !== 'section')
-        	{
+    public function html_secedit_button(Event $event)
+    {
+        global $ID;
+
+        //Section event?
+        if ($event->data['target'] !== 'section' && $event->data['target'] !== 'table')
+        {
             return;
-        	}
+        }
 
         //disable requested?
         if (p_get_metadata($ID,"sectionedit",FALSE) == "off")
-        	{
-	        $event->data['name'] = "";
-        	}
-    	}
-	}
+        {
+            $event->data['name'] = "";
+        }
+    }
+}
+# vi:ts=4 sw=4 et
+#

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    nosecedit
-author  lisps
+author  einhirn,lisps
 email   
-date    2013-10-29
+date    2026-05-22
 name    NoSectionEdit
 desc    Disable SectionEdit-Buttons
 url     http://dokuwiki.org/plugin:nosecedit

--- a/syntax.php
+++ b/syntax.php
@@ -5,94 +5,90 @@
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  lisps
+ * @author  einhirn
  */
 
-if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'syntax.php');
+use dokuwiki\Extension\SyntaxPlugin;
 
 /*
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
  */
 class syntax_plugin_nosecedit extends DokuWiki_Syntax_Plugin
-	{
-		
+{
+
     /*
      * enable sectionedit by default
      */
-	function syntax_plugin_nosecedit()
-		{
-		global $ID;
-		
-		if ($ID != "")
-			{
-			p_set_metadata($ID,array("sectionedit"=>"on"),FALSE,TRUE);
-			}
-		}
+    public function __construct()
+    {
+        global $ID;
+
+        if ($ID != "") {
+            p_set_metadata($ID,array("sectionedit"=>"on"),FALSE,TRUE);
+        }
+    }
 
     /*
      * What kind of syntax are we?
      */
-    function getType()
-    	{
+    public function getType()
+    {
         return 'substition';
-    	}
+    }
 
     /*
      * Where to sort in?
      */
-    function getSort()
-    	{
+    public function getSort()
+    {
         return 155;
-    	}
+    }
 
     /*
      * Paragraph Type
      */
-    function getPType()
-    	{
+    public function getPType()
+    {
         return 'normal';
-    	}
+    }
 
     /*
      * Connect pattern to lexer
      */
-    function connectTo($mode)
-    	{
+    public function connectTo($mode)
+    {
         $this->Lexer->addSpecialPattern("~~NOSECTIONEDIT~~",$mode,'plugin_nosecedit');
-    	}
+    }
 
 
     /*
      * Handle the matches
      */
-    function handle($match, $state, $pos, &$handler)
-    	{
-      	global $ID;
+    public function handle($match, $state, $pos, Doku_Handler $handler)
+    {
+        global $ID;
         return (array($ID=>TRUE));        
-    	}
+    }
     
     /*
      * Create output
      */
-    function render($mode, &$renderer, $opt)
-    	{
-	    global $ID;
+    public function render($mode, Doku_Renderer $renderer, $opt)
+    {
+        global $ID;
 
-	    //save flags to metadata	    
-		//if($mode == 'metadata')
-			{
-	    	if (isset($opt[$ID])==TRUE)
-		    	{
-				p_set_metadata($ID,array("sectionedit"=>"off"),FALSE,TRUE);
-	    		}
-	    	else
-	    		{
-				p_set_metadata($ID,array("sectionedit"=>"on"),FALSE,TRUE);
-	    		}
-    		}
-	    return (TRUE);
+        //save flags to metadata
+        //if($mode == 'metadata')
+        {
+            if (isset($opt[$ID])==TRUE) {
+                p_set_metadata($ID,array("sectionedit"=>"off"),TRUE,TRUE);
+            }
+            else {
+                p_set_metadata($ID,array("sectionedit"=>"on"),FALSE,TRUE);
+            }
         }
-	}
+        return (TRUE);
+    }
+}
 //Setup VIM: ex: et ts=4 enc=utf-8 :


### PR DESCRIPTION
Reformatted code. Now works for table edit buttons, too.

Maybe one could also add a second syntax pattern to only switch off table edit buttons? But that's for another pull request.